### PR TITLE
Improve optimization and embed metadata in PDFs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,7 @@
       overlays = import ./overlays { inherit inputs; };
       overlaysList = with overlays; [
         calibre-acsm-plugin-libcrypto
+        efficient-compression-tool
         overlays.m4b-tool
         unstablePackages
         image_optim

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
       overlaysList = with overlays; [
         calibre-acsm-plugin-libcrypto
         efficient-compression-tool
+        jpegli
         overlays.m4b-tool
         unstablePackages
         image_optim

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -6,6 +6,9 @@
   image_optim = _final: prev: {
     image_optim = prev.image_optim.override { withPngout = true; };
   };
+  efficient-compression-tool = _final: prev: {
+    efficient-compression-tool = prev.callPackage ./efficient-compression-tool/package.nix { };
+  };
   m4b-tool = inputs.m4b-tool.overlay;
   calibre-acsm-plugin-libcrypto = _final: _prev: {
     # calibre = prev.calibre.overrideAttrs (prevAttrs:

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -9,6 +9,9 @@
   efficient-compression-tool = _final: prev: {
     efficient-compression-tool = prev.callPackage ./efficient-compression-tool/package.nix { };
   };
+  jpegli = _final: prev: {
+    jpegli = prev.callPackage ./jpegli/package.nix { };
+  };
   m4b-tool = inputs.m4b-tool.overlay;
   calibre-acsm-plugin-libcrypto = _final: _prev: {
     # calibre = prev.calibre.overrideAttrs (prevAttrs:

--- a/overlays/efficient-compression-tool/package.nix
+++ b/overlays/efficient-compression-tool/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  boost,
+  cmake,
+  nasm,
+  libpng,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "efficient-compression-tool";
+  version = "0.9.5";
+
+  src = fetchFromGitHub {
+    owner = "fhanau";
+    repo = "Efficient-Compression-Tool";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mlqRDYwgLiB/mRaXkkPTCLiDGxTXqEgu5Nz5jhr1Hsg=";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    substituteInPlace src/CMakeLists.txt \
+      --replace-fail 'if(EXISTS "''${CMAKE_SOURCE_DIR}/../.git" AND NOT EXISTS "''${CMAKE_SOURCE_DIR}/../src/libpng/README")' 'if(False)' \
+      --replace-fail 'file(COPY ''${CMAKE_SOURCE_DIR}/pngusr.h DESTINATION ''${CMAKE_SOURCE_DIR}/libpng/)' ""
+    substituteInPlace src/optipng/CMakeLists.txt \
+      --replace-fail 'set(PNG_BUILD_ZLIB ON CACHE BOOL "use custom zlib within libpng" FORCE)' "" \
+      --replace-fail 'add_subdirectory(../libpng libpng EXCLUDE_FROM_ALL)' "" \
+      --replace-fail 'png_static)' 'png)'
+    substituteInPlace src/optipng/image.h src/optipng/trans.h \
+      --replace-fail '#include "../libpng/png.h"' '#include <png.h>'
+    substituteInPlace src/optipng/opngreduc/opngreduc.h \
+      --replace-fail '#include "../../libpng/png.h"' '#include <png.h>'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    nasm
+  ];
+
+  buildInputs = [
+    boost
+    libpng
+  ];
+
+  cmakeDir = "../src";
+
+  cmakeFlags = [ "-DECT_FOLDER_SUPPORT=ON" ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
+  versionCheckProgramArg = "-help";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Fast and effective C++ file optimizer";
+    homepage = "https://github.com/fhanau/Efficient-Compression-Tool";
+    changelog = "https://github.com/fhanau/Efficient-Compression-Tool/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      jwillikers
+      lunik1
+    ];
+    platforms = lib.platforms.all;
+    mainProgram = "ect";
+  };
+})

--- a/overlays/jpegli/package.nix
+++ b/overlays/jpegli/package.nix
@@ -1,0 +1,80 @@
+{
+  stdenv,
+  lib,
+  asciidoc,
+  cmake,
+  fetchFromGitHub,
+  gtest,
+  python3,
+  libpng,
+  giflib,
+  lcms2,
+  libhwy,
+  brotli,
+  ninja,
+  pkg-config,
+  unstableGitUpdater,
+}:
+stdenv.mkDerivation {
+  pname = "jpegli";
+  version = "0-unstable-2025-02-11";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "jpegli";
+    rev = "bc19ca2393f79bfe0a4a9518f77e4ad33ce1ab7a";
+    hash = "sha256-8th+QHLOoAIbSJwFyaBxUXoCXwj7K7rgg/cCK7LgOb0=";
+    fetchSubmodules = true;
+  };
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  nativeBuildInputs = [
+    asciidoc
+    cmake
+    gtest
+    ninja
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    brotli
+    giflib
+    lcms2
+    libhwy
+    libpng
+  ];
+
+  cmakeFlags = [
+    "-DJPEGXL_ENABLE_JPEGLI_LIBJPEG=No"
+    "-DJPEGXL_BUNDLE_LIBPNG=No"
+    "-DJPEGXL_FORCE_SYSTEM_BROTLI=Yes"
+    "-DJPEGXL_FORCE_SYSTEM_GTEST=Yes"
+    "-DJPEGXL_FORCE_SYSTEM_LCMS2=Yes"
+    "-DJPEGXL_FORCE_SYSTEM_HWY=Yes"
+    # Enable hardware-dependent optimizations
+    "-DJPEGXL_ENABLE_SIZELESS_VECTORS=Yes"
+    "-DJPEGXL_ENABLE_AVX512=Yes"
+    "-DJPEGXL_ENABLE_AVX512_SPR=Yes"
+    "-DJPEGXL_ENABLE_AVX512_ZEN4=Yes"
+  ];
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
+  };
+
+  meta = {
+    description = "Improved JPEG encoder and decoder implementation";
+    homepage = "https://github.com/google/jpegli";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ jwillikers ];
+    mainProgram = "cjpegli";
+  };
+}

--- a/packages/media-juggler/import-comics.nu
+++ b/packages/media-juggler/import-comics.nu
@@ -6,6 +6,7 @@
 
 # todo Place the Calibre library and database in the temporary directory
 
+use std assert
 use std log
 use media-juggler-lib *
 
@@ -297,7 +298,7 @@ def main [
 
   if $clear_comictagger_cache {
     log debug "Clearing the ComicTagger cache"
-    rm --force --recursive ([$env.HOME ".cache" "ComicTagger"] | path join)
+    rm --force --recursive ([($nu.cache-dir | path dirname) "ComicTagger"] | path join)
   }
 
   let results = $files | each {|original_file|
@@ -660,8 +661,8 @@ def main [
         $formats
         | get $input_format
         | fetch_book_metadata --isbn $isbn $temporary_directory
-        | export_book_to_directory $temporary_directory
-        | embed_book_metadata $temporary_directory
+        | export_book_to_directory ($formats | get $input_format | path dirname)
+        | embed_book_metadata
         | get book
       )
     } else {
@@ -949,8 +950,8 @@ def main [
           --title $title
           $temporary_directory
         )
-        | export_book_to_directory $temporary_directory
-        | embed_book_metadata $temporary_directory
+        | export_book_to_directory ($formats | get "epub" | path dirname)
+        | embed_book_metadata
         | (
           let input = $in;
           (

--- a/packages/media-juggler/import-ebooks.nu
+++ b/packages/media-juggler/import-ebooks.nu
@@ -236,259 +236,259 @@ def main [
     log debug $"Found the cover file (ansi yellow)($original_cover)(ansi reset)"
   }
 
-    # todo Extract the cover from metadata?
-    let cover = (
-      if $original_cover != null {
-        let target = [$temporary_directory ($original_cover | path basename)] | path join
-        if ($original_cover | is_ssh_path) {
-          log debug $"Downloading the file (ansi yellow)($original_cover)(ansi reset) to (ansi yellow)($target)(ansi reset)"
-          if $use_rsync {
-            $original_cover | rsync $target "--mkpath"
+  # todo Extract the cover from metadata?
+  let cover = (
+    if $original_cover != null {
+      let target = [$temporary_directory ($original_cover | path basename)] | path join
+      if ($original_cover | is_ssh_path) {
+        log debug $"Downloading the file (ansi yellow)($original_cover)(ansi reset) to (ansi yellow)($target)(ansi reset)"
+        if $use_rsync {
+          $original_cover | rsync $target "--mkpath"
+        } else {
+          $original_cover | scp $target --mkdir
+        }
+      } else {
+        log debug $"Copying the file (ansi yellow)($original_cover)(ansi reset) to (ansi yellow)($target)(ansi reset)"
+        cp $original_cover $target
+      }
+      $target
+    }
+  )
+  [$cover] | optimize_images
+
+  let original_book_files = [($original_file | split_ssh_path | get path)] | append $original_cover | append $original_opf
+  log debug $"The original files for the book are (ansi yellow)($original_book_files)(ansi reset)"
+
+  let input_format = ($file | path parse | get extension)
+  let output_format = (
+    if $input_format == "pdf" {
+      "pdf"
+    } else {
+      "epub"
+    }
+  )
+
+  let formats = (
+    if $input_format == "acsm" {
+      let epub = ($file | acsm_to_epub (pwd))
+      { book: $epub }
+    } else if $input_format in ["epub" "pdf"] {
+      { book: $file }
+    } else {
+      rm --force --recursive $temporary_directory
+      return {
+        file: $original_file
+        error: $"Unsupported input file type (ansi red_bold)($input_format)(ansi reset)"
+      }
+    }
+  )
+
+  let original_metadata = $file | get_metadata $temporary_directory
+
+  log debug "Attempting to get the ISBN from existing metadata"
+  let metadata_isbn = $original_metadata | isbn_from_metadata
+  if $metadata_isbn != null {
+    log debug $"Found the ISBN (ansi purple)($metadata_isbn)(ansi reset) in the book's metadata"
+  }
+
+  log debug "Attempting to get the ISBN from the first ten and last ten pages of the book"
+  let book_isbn_numbers = (
+    let isbn_numbers = $file | isbn_from_pages $temporary_directory;
+    if ($isbn_numbers | is-empty) {
+      # Check images for the ISBN if text doesn't work out.
+      if "pdf" in $formats {
+        let cbz = $formats.pdf | cbconvert --format "jpeg" --quality 90
+        let isbn_from_cbz = $cbz | isbn_from_pages $temporary_directory
+        rm $cbz
+        if ($isbn_from_cbz | is-not-empty) {
+          $isbn_from_cbz
+        }
+      } else if "epub" in $formats {
+        let isbn_from_epub = $formats.epub | isbn_from_pages $temporary_directory
+        if ($isbn_from_epub | is-not-empty) {
+          $isbn_from_epub
+        }
+      }
+    } else {
+      $isbn_numbers
+    }
+  )
+  if $book_isbn_numbers != null and ($book_isbn_numbers | is-not-empty) {
+    log debug $"Found ISBN numbers in the book's pages: (ansi purple)($book_isbn_numbers)(ansi reset)"
+  }
+
+  # Determine the most likely ISBN from the metadata and pages
+  let likely_isbn_from_pages_and_metadata = (
+    if $metadata_isbn != null and $book_isbn_numbers != null {
+      if ($book_isbn_numbers | is-empty) {
+        log debug $"No ISBN numbers found in the pages of the book. Using the ISBN from the book's metadata (ansi purple)($metadata_isbn)(ansi reset)"
+        $metadata_isbn
+      } else if $metadata_isbn in $book_isbn_numbers {
+        if ($book_isbn_numbers | length) == 1 {
+          log debug "Found an exact match between the ISBN in the metadata and the ISBN in the pages of the book"
+        } else if ($book_isbn_numbers | length) > 10 {
+          rm --force --recursive $temporary_directory
+          return {
+            file: $original_file
+            error: $"Found more than 10 ISBN numbers in the pages of the book: (ansi purple)($book_isbn_numbers)(ansi reset)"
+          }
+        }
+        $metadata_isbn
+      } else {
+        # todo If only one number is available in the pages, should it be preferred?
+        log warning $"The ISBN from the book's metadata, (ansi purple)($metadata_isbn)(ansi reset) not among the ISBN numbers found in the books pages: (ansi purple)($book_isbn_numbers)(ansi reset)."
+        if ($book_isbn_numbers | length) == 1 {
+          log warning $"The ISBN from the book's metadata, (ansi purple)($metadata_isbn)(ansi reset) not among the ISBN numbers found in the books pages: (ansi purple)($book_isbn_numbers)(ansi reset)."
+          $book_isbn_numbers | first
+        } else {
+          if $isbn == null {
+            rm --force --recursive $temporary_directory
+            return {
+              file: $original_file
+              error: $"The ISBN from the book's metadata, (ansi purple)($metadata_isbn)(ansi reset) not among the ISBN numbers found in the books pages: (ansi purple)($book_isbn_numbers)(ansi reset). Use the `--isbn` flag to set the ISBN instead."
+            }
           } else {
-            $original_cover | scp $target --mkdir
+            log warning $"The ISBN from the book's metadata, (ansi purple)($metadata_isbn)(ansi reset) not among the ISBN numbers found in the books pages: (ansi purple)($book_isbn_numbers)(ansi reset)."
+          }
+        }
+      }
+    } else if $metadata_isbn != null {
+      log debug $"No ISBN numbers found in the pages of the book. Using the ISBN from the book's metadata (ansi purple)($metadata_isbn)(ansi reset)"
+      $metadata_isbn
+    } else if $book_isbn_numbers != null and ($book_isbn_numbers | is-not-empty) {
+      if ($book_isbn_numbers | length) == 1 {
+        log debug $"Found a single ISBN in the pages of the book: (ansi purple)($book_isbn_numbers | first)(ansi reset)"
+        $book_isbn_numbers | first
+      } else if ($book_isbn_numbers | length) > 10 {
+        log warning $"Found more than 10 ISBN numbers in the pages of the book: (ansi purple)($book_isbn_numbers)(ansi reset)"
+      } else {
+        log warning $"Found multiple ISBN numbers in the pages of the book: (ansi purple)($book_isbn_numbers)(ansi reset)"
+      }
+    } else {
+      log debug "No ISBN numbers found in the metadata or pages of the book"
+    }
+  )
+
+  let isbn = (
+    if $isbn == null {
+      if $likely_isbn_from_pages_and_metadata == null {
+        log warning $"Unable to determine the ISBN from metadata or the pages of the book"
+      } else {
+        $likely_isbn_from_pages_and_metadata
+      }
+    } else {
+      if $likely_isbn_from_pages_and_metadata != null {
+        if $isbn == $likely_isbn_from_pages_and_metadata {
+          log debug "The provided ISBN matches the one found using the book's metadata and pages"
+        } else {
+          log warning $"The provided ISBN (ansi purple)($isbn)(ansi reset) does not match the one found using the book's metadata and pages (ansi purple)($likely_isbn_from_pages_and_metadata)(ansi reset)"
+        }
+      } else if $book_isbn_numbers != null and ($book_isbn_numbers | is-not-empty) {
+        if $isbn in $book_isbn_numbers {
+          log debug $"The provided ISBN is among those found in the book's pages: (ansi purple)($book_isbn_numbers)(ansi reset)"
+        } else {
+          log warning $"The provided ISBN is not among those found in the book's pages: (ansi purple)($book_isbn_numbers)(ansi reset)"
+        }
+      }
+      $isbn
+    }
+  )
+  if $isbn != null {
+    log debug $"The ISBN is (ansi purple)($isbn)(ansi reset)"
+  }
+
+  let book = (
+    $formats.book
+    | (
+      let input = $in;
+      if $isbn == null or ($isbn | is-empty) {
+        # Don't use Kobo unless we know the ISBN... or it will probably find something arbitrary and wrong instead of the actual book.
+        let result = $input | fetch_book_metadata --allowed-plugins ["Google" "Amazon.com"] $temporary_directory
+        if $result.opf == null {
+          {
+            book: $input
+            cover: null
+            opf: null
           }
         } else {
-          log debug $"Copying the file (ansi yellow)($original_cover)(ansi reset) to (ansi yellow)($target)(ansi reset)"
-          cp $original_cover $target
+          let original_title = $original_metadata | title_from_metadata
+          let fetched_title = $result.opf | title_from_opf
+          if $fetched_title == $original_title {
+            $result
+          } else {
+            log warning $"The fetched title (ansi yellow)($fetched_title)(ansi reset) does not match the original title (ansi yellow)($original_title)(ansi reset). Ignoring metadata."
+            {
+              book: $input
+              cover: null
+              opf: null
+            }
+          }
         }
-        $target
-      }
-    )
-    [$cover] | optimize_images
-
-    let original_book_files = [($original_file | split_ssh_path | get path)] | append $original_cover | append $original_opf
-    log debug $"The original files for the book are (ansi yellow)($original_book_files)(ansi reset)"
-
-    let input_format = ($file | path parse | get extension)
-    let output_format = (
-      if $input_format == "pdf" {
-        "pdf"
       } else {
-        "epub"
+        # todo output details of discovered metadata for verification
+        let result = $input | fetch_book_metadata --isbn $isbn $temporary_directory
+        if $result.opf == null {
+          {
+            book: $input
+            cover: null
+            opf: null
+          }
+        } else {
+          let fetched_isbn = $result.opf | isbn_from_opf
+          if $fetched_isbn == null or ($fetched_isbn | is-empty) {
+            log warning "No ISBN in retrieved metadata!"
+            $result
+          } else if $fetched_isbn == $isbn {
+            $result
+          } else {
+            log info "Fetched ISBN doesn't match the ISBN used to search! Will attempt another search with only the Google and Amazon.com metadata sources"
+            let result = $input | fetch_book_metadata --allowed-plugins ["Google" "Amazon.com"] --isbn $isbn $temporary_directory
+            if $result.opf == null {
+              {
+                book: $input
+                cover: null
+                opf: null
+              }
+            } else {
+              let fetched_isbn = $result.opf | isbn_from_opf
+              if $fetched_isbn == null or ($fetched_isbn | is-empty) {
+                log warning "No ISBN in retrieved metadata!"
+                $result
+              } else if $fetched_isbn == $isbn {
+                $result
+              } else {
+                log warning "No metadata found!"
+                {
+                  book: $input
+                  cover: null
+                  opf: null
+                }
+              }
+            }
+          }
+        }
       }
     )
-
-    let formats = (
-      if $input_format == "acsm" {
-        let epub = ($file | acsm_to_epub (pwd))
-        { book: $epub }
-      } else if $input_format in ["epub" "pdf"] {
-        { book: $file }
-      } else {
-        rm --force --recursive $temporary_directory
-        return {
-          file: $original_file
-          error: $"Unsupported input file type (ansi red_bold)($input_format)(ansi reset)"
-        }
-      }
-    )
-
-    let original_metadata = $file | get_metadata $temporary_directory
-
-    log debug "Attempting to get the ISBN from existing metadata"
-    let metadata_isbn = $original_metadata | isbn_from_metadata
-    if $metadata_isbn != null {
-        log debug $"Found the ISBN (ansi purple)($metadata_isbn)(ansi reset) in the book's metadata"
-    }
-
-    log debug "Attempting to get the ISBN from the first ten and last ten pages of the book"
-    let book_isbn_numbers = (
-        let isbn_numbers = $file | isbn_from_pages $temporary_directory;
-        if ($isbn_numbers | is-empty) {
-            # Check images for the ISBN if text doesn't work out.
-            if "pdf" in $formats {
-                let cbz = $formats.pdf | cbconvert --format "jpeg" --quality 90
-                let isbn_from_cbz = $cbz | isbn_from_pages $temporary_directory
-                rm $cbz
-                if ($isbn_from_cbz | is-not-empty) {
-                    $isbn_from_cbz
-                }
-            } else if "epub" in $formats {
-                let isbn_from_epub = $formats.epub | isbn_from_pages $temporary_directory
-                if ($isbn_from_epub | is-not-empty) {
-                    $isbn_from_epub
-                }
-            }
+    | (
+      let input = $in;
+      $input | update opf (
+        if $input.opf != null {
+          # todo Should probably have a better way of merging metadata
+          $original_metadata.opf | merge $input.opf
         } else {
-          $isbn_numbers
+          $original_metadata.opf
         }
-    )
-    if $book_isbn_numbers != null and ($book_isbn_numbers | is-not-empty) {
-      log debug $"Found ISBN numbers in the book's pages: (ansi purple)($book_isbn_numbers)(ansi reset)"
-    }
-
-    # Determine the most likely ISBN from the metadata and pages
-    let likely_isbn_from_pages_and_metadata = (
-        if $metadata_isbn != null and $book_isbn_numbers != null {
-            if ($book_isbn_numbers | is-empty) {
-                log debug $"No ISBN numbers found in the pages of the book. Using the ISBN from the book's metadata (ansi purple)($metadata_isbn)(ansi reset)"
-                $metadata_isbn
-            } else if $metadata_isbn in $book_isbn_numbers {
-                if ($book_isbn_numbers | length) == 1 {
-                    log debug "Found an exact match between the ISBN in the metadata and the ISBN in the pages of the book"
-                } else if ($book_isbn_numbers | length) > 10 {
-                    rm --force --recursive $temporary_directory
-                    return {
-                        file: $original_file
-                        error: $"Found more than 10 ISBN numbers in the pages of the book: (ansi purple)($book_isbn_numbers)(ansi reset)"
-                    }
-                }
-                $metadata_isbn
-            } else {
-                # todo If only one number is available in the pages, should it be preferred?
-                log warning $"The ISBN from the book's metadata, (ansi purple)($metadata_isbn)(ansi reset) not among the ISBN numbers found in the books pages: (ansi purple)($book_isbn_numbers)(ansi reset)."
-                if ($book_isbn_numbers | length) == 1 {
-                    log warning $"The ISBN from the book's metadata, (ansi purple)($metadata_isbn)(ansi reset) not among the ISBN numbers found in the books pages: (ansi purple)($book_isbn_numbers)(ansi reset)."
-                    $book_isbn_numbers | first
-                } else {
-                    if $isbn == null {
-                        rm --force --recursive $temporary_directory
-                        return {
-                            file: $original_file
-                            error: $"The ISBN from the book's metadata, (ansi purple)($metadata_isbn)(ansi reset) not among the ISBN numbers found in the books pages: (ansi purple)($book_isbn_numbers)(ansi reset). Use the `--isbn` flag to set the ISBN instead."
-                        }
-                    } else {
-                        log warning $"The ISBN from the book's metadata, (ansi purple)($metadata_isbn)(ansi reset) not among the ISBN numbers found in the books pages: (ansi purple)($book_isbn_numbers)(ansi reset)."
-                    }
-                }
-            }
-        } else if $metadata_isbn != null {
-            log debug $"No ISBN numbers found in the pages of the book. Using the ISBN from the book's metadata (ansi purple)($metadata_isbn)(ansi reset)"
-            $metadata_isbn
-        } else if $book_isbn_numbers != null and ($book_isbn_numbers | is-not-empty) {
-            if ($book_isbn_numbers | length) == 1 {
-                log debug $"Found a single ISBN in the pages of the book: (ansi purple)($book_isbn_numbers | first)(ansi reset)"
-                $book_isbn_numbers | first
-            } else if ($book_isbn_numbers | length) > 10 {
-                log warning $"Found more than 10 ISBN numbers in the pages of the book: (ansi purple)($book_isbn_numbers)(ansi reset)"
-            } else {
-                log warning $"Found multiple ISBN numbers in the pages of the book: (ansi purple)($book_isbn_numbers)(ansi reset)"
-            }
+      ) | update cover (
+        if $cover != null {
+          $cover
         } else {
-            log debug "No ISBN numbers found in the metadata or pages of the book"
+          $input.cover
         }
+      )
     )
-
-    let isbn = (
-        if $isbn == null {
-            if $likely_isbn_from_pages_and_metadata == null {
-                log warning $"Unable to determine the ISBN from metadata or the pages of the book"
-            } else {
-                $likely_isbn_from_pages_and_metadata
-            }
-        } else {
-            if $likely_isbn_from_pages_and_metadata != null {
-                if $isbn == $likely_isbn_from_pages_and_metadata {
-                    log debug "The provided ISBN matches the one found using the book's metadata and pages"
-                } else {
-                    log warning $"The provided ISBN (ansi purple)($isbn)(ansi reset) does not match the one found using the book's metadata and pages (ansi purple)($likely_isbn_from_pages_and_metadata)(ansi reset)"
-                }
-            } else if $book_isbn_numbers != null and ($book_isbn_numbers | is-not-empty) {
-                if $isbn in $book_isbn_numbers {
-                    log debug $"The provided ISBN is among those found in the book's pages: (ansi purple)($book_isbn_numbers)(ansi reset)"
-                } else {
-                    log warning $"The provided ISBN is not among those found in the book's pages: (ansi purple)($book_isbn_numbers)(ansi reset)"
-                }
-            }
-            $isbn
-        }
-    )
-    if $isbn != null {
-        log debug $"The ISBN is (ansi purple)($isbn)(ansi reset)"
-    }
-
-    let book = (
-        $formats.book
-        | (
-            let input = $in;
-            if $isbn == null or ($isbn | is-empty) {
-                # Don't use Kobo unless we know the ISBN... or it will probably find something arbitrary and wrong instead of the actual book.
-                let result = $input | fetch_book_metadata --allowed-plugins ["Google" "Amazon.com"] $temporary_directory
-                if $result.opf == null {
-                    {
-                        book: $input
-                        cover: null
-                        opf: null
-                    }
-                } else {
-                    let original_title = $original_metadata | title_from_metadata
-                    let fetched_title = $result.opf | title_from_opf
-                    if $fetched_title == $original_title {
-                        $result
-                    } else {
-                        log warning $"The fetched title (ansi yellow)($fetched_title)(ansi reset) does not match the original title (ansi yellow)($original_title)(ansi reset). Ignoring metadata."
-                        {
-                            book: $input
-                            cover: null
-                            opf: null
-                        }
-                    }
-                }
-            } else {
-                # todo output details of discovered metadata for verification
-                let result = $input | fetch_book_metadata --isbn $isbn $temporary_directory
-                if $result.opf == null {
-                    {
-                        book: $input
-                        cover: null
-                        opf: null
-                    }
-                } else {
-                    let fetched_isbn = $result.opf | isbn_from_opf
-                    if $fetched_isbn == null or ($fetched_isbn | is-empty) {
-                        log warning "No ISBN in retrieved metadata!"
-                        $result
-                    } else if $fetched_isbn == $isbn {
-                        $result
-                    } else {
-                        log info "Fetched ISBN doesn't match the ISBN used to search! Will attempt another search with only the Google and Amazon.com metadata sources"
-                        let result = $input | fetch_book_metadata --allowed-plugins ["Google" "Amazon.com"] --isbn $isbn $temporary_directory
-                        if $result.opf == null {
-                            {
-                                book: $input
-                                cover: null
-                                opf: null
-                            }
-                        } else {
-                            let fetched_isbn = $result.opf | isbn_from_opf
-                            if $fetched_isbn == null or ($fetched_isbn | is-empty) {
-                                log warning "No ISBN in retrieved metadata!"
-                                $result
-                            } else if $fetched_isbn == $isbn {
-                                $result
-                            } else {
-                                log warning "No metadata found!"
-                                {
-                                    book: $input
-                                    cover: null
-                                    opf: null
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        )
-        | (
-            let input = $in;
-            $input | update opf (
-                if $input.opf != null {
-                  # todo Should probably have a better way of merging metadata
-                  $original_metadata.opf | merge $input.opf
-                } else {
-                  $original_metadata.opf
-                }
-            ) | update cover (
-                if $cover != null {
-                  $cover
-                } else {
-                  $input.cover
-                }
-            )
-        )
-        | export_book_to_directory ($formats.book | path dirname)
-        | embed_book_metadata
-    )
+    | export_book_to_directory ($formats.book | path dirname)
+    | embed_book_metadata
+  )
 
   let optimized_file_hashes = (
     try {

--- a/packages/media-juggler/import-ebooks.nu
+++ b/packages/media-juggler/import-ebooks.nu
@@ -473,21 +473,21 @@ def main [
             let input = $in;
             $input | update opf (
                 if $input.opf != null {
-                    # todo Should probably have a better way of merging metadata
-                    $original_metadata.opf | merge $input.opf
+                  # todo Should probably have a better way of merging metadata
+                  $original_metadata.opf | merge $input.opf
                 } else {
-                    $original_metadata.opf
+                  $original_metadata.opf
                 }
             ) | update cover (
                 if $cover != null {
-                    $cover
+                  $cover
                 } else {
-                    $input.cover
+                  $input.cover
                 }
             )
         )
-        | export_book_to_directory $temporary_directory
-        | embed_book_metadata $temporary_directory
+        | export_book_to_directory ($formats.book | path dirname)
+        | embed_book_metadata
     )
 
   let optimized_file_hashes = (

--- a/packages/media-juggler/media-juggler-lib/mod.nu
+++ b/packages/media-juggler/media-juggler-lib/mod.nu
@@ -1601,6 +1601,7 @@ export def advzip_recompress [
 }
 
 # Optimize a ZIP archive using efficient-compression-tool
+# todo Use a temporary file to avoid corruption
 export def optimize_zip_ect [
   optimization_level: int = 9 # The degree to which to optimize the zip archive from 1 to 9, with 9 being the best compression possible
   ...args: string # Extra arguments to pass to advzip
@@ -1892,11 +1893,11 @@ export def comic_file_name_from_metadata [
                 | first
             )
         } else if $title =~ ".+ [0-9]+" {
-            $title
-            | parse --regex '(?P<series>.+) (?P<issue>[0-9]+)'
-            | first
+          $title
+          | parse --regex '(?P<series>.+) (?P<issue>[0-9]+)'
+          | first
         } else {
-            { series: $title, issue: 1 }
+          { series: $title, issue: 1 }
         }
       }
     )
@@ -1905,36 +1906,36 @@ export def comic_file_name_from_metadata [
     }
 
     let series = (
-        if $series == null {
-            if $parsed_title == null {
-                null
-            } else {
-                log debug $"Parsed the series as (ansi purple)'($parsed_title.series)'(ansi reset) from the title"
-                $parsed_title.series
-            }
+      if $series == null {
+        if $parsed_title == null {
+          null
         } else {
-            $series
+          log debug $"Parsed the series as (ansi purple)'($parsed_title.series)'(ansi reset) from the title"
+          $parsed_title.series
         }
+      } else {
+        $series
+      }
     )
     let issue = (
-        if $issue == null {
-            if $parsed_title == null {
-                null
-            } else {
-                log debug $"Parsed the issue as (ansi purple)'($parsed_title.issue)'(ansi reset) from the title"
-                $parsed_title.issue
-            }
+      if $issue == null {
+        if $parsed_title == null {
+          null
         } else {
-            $issue
+          log debug $"Parsed the issue as (ansi purple)'($parsed_title.issue)'(ansi reset) from the title"
+          $parsed_title.issue
         }
+      } else {
+        $issue
+      }
     )
 
-    if $series == null and $issue == null {
-        log error $"Unable to determine the series and issue from the metadata title '($title)'. Pass the Comic Vine issue id with the (ansi green)--comic-vine-issue-id(ansi reset) flag."
-        $file
-    } else {
-        $file | path parse | update stem $"($series) \(($series_year)\) #($issue) \(($issue_year)\)" | path join
-    }
+  if $series == null and $issue == null {
+    log error $"Unable to determine the series and issue from the metadata title '($title)'. Pass the Comic Vine issue id with the (ansi green)--comic-vine-issue-id(ansi reset) flag."
+    $file
+  } else {
+    $file | path parse | update stem $"($series) \(($series_year)\) #($issue) \(($issue_year)\)" | path join
+  }
 }
 
 # Convert a FLAC to an OGA
@@ -2043,25 +2044,25 @@ export def tag_epub_comic_vine [
     let epub = $in
     let opf_file = ({ parent: $working_directory, stem: $comic_vine_issue_id, extension: "opf" } | path join)
     let opf = (
-        ^fetch-ebook-metadata
-            --allowed-plugin "Comicvine"
-            --identifier $"comicvine:($comic_vine_issue_id)"
-            --opf
-        | from xml
+      ^fetch-ebook-metadata
+        --allowed-plugin "Comicvine"
+        --identifier $"comicvine:($comic_vine_issue_id)"
+        --opf
+      | from xml
     )
     log debug $"The opf metadata for Comic Vine issue id (ansi purple_bold)($comic_vine_issue_id)(ansi reset) is:\n($opf)\n"
     # todo edit XML directly?
     (
-        $opf
-        | to xml
-        | save --force $opf_file
+      $opf
+      | to xml
+      | save --force $opf_file
     )
     (
-        ^ebook-meta
-            $epub
-            --authors ($authors | str join "&")
-            --from-opf $"($working_directory)/($comic_vine_issue_id).opf"
-            --title $title
+      ^ebook-meta
+        $epub
+        --authors ($authors | str join "&")
+        --from-opf $"($working_directory)/($comic_vine_issue_id).opf"
+        --title $title
     )
     rm $opf_file
     $epub
@@ -2500,7 +2501,9 @@ export def export_book_to_directory [
     | path join
   )
   mv $input.cover $cover
+  log debug $"Renaming book from (ansi yellow)($input.book)(ansi reset) to (ansi yellow)($book)(ansi reset)"
   mv $input.book $book
+  log debug $"Book contents in the directory (ansi purple)($target_directory)(ansi reset)";
   {
     book: $book
     opf: $opf
@@ -2509,9 +2512,7 @@ export def export_book_to_directory [
 }
 
 # todo Pass around opf as metadata instead of a file path.
-export def embed_book_metadata [
-  working_directory: path
-]: [
+export def embed_book_metadata []: [
   record<book: path, cover: path, opf: path> -> record<book: path, cover: path, opf: path>
 ] {
   let input = $in

--- a/packages/media-juggler/package.nix
+++ b/packages/media-juggler/package.nix
@@ -8,6 +8,7 @@
   ffmpeg,
   file,
   image_optim,
+  jpegli,
   keyfinder-cli,
   lib,
   m4b-tool,
@@ -77,6 +78,7 @@ else
             cbconvert
             efficient-compression-tool
             image_optim
+            jpegli
             minuimus
             # kcc
             udisks
@@ -91,6 +93,7 @@ else
             efficient-compression-tool
             ffmpeg
             image_optim
+            jpegli
             minuimus
             m4b-tool
             tone
@@ -106,6 +109,7 @@ else
             # comictagger
             efficient-compression-tool
             image_optim
+            jpegli
             # kcc
             minuimus
             mupdf-headless
@@ -123,6 +127,7 @@ else
             efficient-compression-tool
             file
             image_optim
+            jpegli
             minuimus
             mupdf-headless
             tesseract
@@ -138,6 +143,7 @@ else
             unstable.beets
             efficient-compression-tool
             image_optim
+            jpegli
             keyfinder-cli
             picard # For mbsubmit Beets plugin
           ]

--- a/packages/minuimus/image_optim.patch
+++ b/packages/minuimus/image_optim.patch
@@ -1,5 +1,5 @@
 diff --git a/minuimus.pl b/minuimus.pl
-index 37fca59..69c9eee 100755
+index 37fca59..5e69958 100755
 --- a/minuimus.pl
 +++ b/minuimus.pl
 @@ -223,7 +223,7 @@ sub compressfile($%) {
@@ -168,7 +168,7 @@ index 37fca59..69c9eee 100755
 -  `which pngout`;
 -  if(! $?) {$optimisers = $optimisers.",pngout";}
 - `which imgdataopt`;
-+  my $optimisers='--use-image-optimizer=oxipngmax';
++  my $optimisers='--use-image-optimizer=oxipngmax_ect';
 +  # my $optimisers='--use-image-optimizer=pngcrush,oxipng,optipng,pngquant,pngout,ect,advpng';
 +  # `which pngout`;
 +  # if(! $?) {$optimisers = $optimisers.",pngout";}

--- a/packages/minuimus/image_optim.patch
+++ b/packages/minuimus/image_optim.patch
@@ -1,5 +1,5 @@
 diff --git a/minuimus.pl b/minuimus.pl
-index 37fca59..b2cbb9a 100755
+index 37fca59..69c9eee 100755
 --- a/minuimus.pl
 +++ b/minuimus.pl
 @@ -223,7 +223,7 @@ sub compressfile($%) {
@@ -168,7 +168,7 @@ index 37fca59..b2cbb9a 100755
 -  `which pngout`;
 -  if(! $?) {$optimisers = $optimisers.",pngout";}
 - `which imgdataopt`;
-+  my $optimisers='--use-image-optimizer=image_optim';
++  my $optimisers='--use-image-optimizer=oxipngmax';
 +  # my $optimisers='--use-image-optimizer=pngcrush,oxipng,optipng,pngquant,pngout,ect,advpng';
 +  # `which pngout`;
 +  # if(! $?) {$optimisers = $optimisers.",pngout";}

--- a/packages/pdfsizeopt/image_optim.patch
+++ b/packages/pdfsizeopt/image_optim.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/pdfsizeopt/main.py b/lib/pdfsizeopt/main.py
-index 48b2791..66f7f59 100644
+index 48b2791..3bf2e3c 100644
 --- a/lib/pdfsizeopt/main.py
 +++ b/lib/pdfsizeopt/main.py
 @@ -6936,6 +6936,8 @@ class PdfData(object):
@@ -41,15 +41,16 @@ index 48b2791..66f7f59 100644
              image_item = self.ConvertImage(
                  sourcefn=oi_image.file_name,
                  is_inverted=oi_image.is_inverted,
-@@ -9431,12 +9438,22 @@ IMAGE_OPTIMIZER_CMD_MAP = {
+@@ -9431,14 +9438,25 @@ IMAGE_OPTIMIZER_CMD_MAP = {
      # We need the -force flag specified to pngout, because on Windows
      # pngout without the -force flag returns with a failure exit code
      # if it can't compress the file any further.
 -    'pngout': 'pngout -force %(pngout_gray_flags)s%(sourcefnq)s %(targetfnq)s',
 -    'jbig2': 'jbig2 -p %(sourcefnq)s >%(targetfnq)s',
 -    'zopflipng': 'zopflipng -y -m --filters=p %(sourcefnq)s %(targetfnq)s',
-+    'image_optim': 'image_optim %(targetfnq)s && ect -9 -strip %(targetfnq)s',
-+    'oxipng_ect': 'oxipng --interlace 0 --quiet --strip all -o 3 -- %(targetfnq)s && ect -9 -strip %(targetfnq)s',
++    'image_optim': 'image_optim %(targetfnq)s && ect -9 -strip --mt-deflate %(targetfnq)s',
++    'oxipng_ect': 'oxipng --interlace 0 --quiet --strip all -o 3 -- %(targetfnq)s && ect -9 -strip --mt-deflate %(targetfnq)s',
++    'oxipngmax_ect': 'oxipng --interlace 0 --quiet --strip all -o max -- %(targetfnq)s && ect -9 -strip --mt-deflate %(targetfnq)s',
 +    # 'image_optim_set': 'pngcrush -blacken -ow -q -rem alla -reduce %(image_optim_set_gray_flags)s%(targetfnq)s && oxipng --interlace 0 --quiet --strip all -o 3 -- %(targetfnq)s && pngquant --force --output=%(targetfnq)s --quality=100-100 --skip-if-larger --speed=3 256 -- %(targetfnq)s || true && advpng -z3 -f %(targetfnq)s && ect -9 -strip %(targetfnq)s',
 +    # 'image_optim_set_all': 'pngcrush -blacken -ow -q -rem alla -reduce %(pngcrush_gray_flags)s%(sourcefnq)s %(targetfnq)s && oxipng --interlace 0 --quiet --strip all -o 3 -- %(targetfnq)s && optipng %(targetfnq)s -clobber -o4 -fix -force %(optipng_gray_flags)s && pngquant --force --output=%(targetfnq)s --quality=100-100 --skip-if-larger --speed=3 256 -- %(targetfnq)s || true && pngout -force %(pngout_gray_flags)s%(targetfnq)s && advpng -z3 -f %(targetfnq)s && ect -9 -strip %(targetfnq)s',
 +    # 'image_optim_set_oxipng_max': 'pngcrush -ow -blacken -q -rem alla -reduce %(pngcrush_gray_flags)s%(sourcefnq)s %(targetfnq)s && oxipng --interlace 0 --quiet --strip all -o max -- %(targetfnq)s && optipng %(sourcefnq)s -o4 -fix -force %(optipng_gray_flags)s-out %(targetfnq)s && pngquant --force --output=%(targetfnq)s --quality=100-100 --skip-if-larger --speed=3 256 -- %(sourcefnq)s || true && pngout -force %(pngout_gray_flags)s%(sourcefnq)s %(targetfnq)s && advpng -z3 -f %(targetfnq)s && ect -9 -strip %(targetfnq)s',
@@ -60,10 +61,14 @@ index 48b2791..66f7f59 100644
      'optipng':  'optipng %(sourcefnq)s -o4 -fix -force %(optipng_gray_flags)s-out %(targetfnq)s',
      'optipng4': 'optipng %(sourcefnq)s -o4 -fix -force %(optipng_gray_flags)s-out %(targetfnq)s',
      'optipng7': 'optipng %(sourcefnq)s -o7 -fix -force %(optipng_gray_flags)s-out %(targetfnq)s',  # Slowest.
+-    'ect': 'ect -9 -strip %(targetfnq)s',
+-    'ECT': 'ect -9 -strip %(targetfnq)s',
 +    'pngquant': 'pngquant --force --output=%(targetfnq)s --quality=100-100 --skip-if-larger --speed=3 256 -- %(sourcefnq)s',
 +    'pngout': 'pngout -force %(pngout_gray_flags)s%(sourcefnq)s %(targetfnq)s',
 +    'jbig2': 'jbig2 -p %(sourcefnq)s >%(targetfnq)s',
 +    'zopflipng': 'zopflipng -y -m --filters=p %(sourcefnq)s %(targetfnq)s',
-     'ect': 'ect -9 -strip %(targetfnq)s',
-     'ECT': 'ect -9 -strip %(targetfnq)s',
++    'ect': 'ect -9 -strip --mt-deflate %(targetfnq)s',
++    'ECT': 'ect -9 -strip --mt-deflate %(targetfnq)s',
      'advpng':  'advpng -z3 -f %(targetfnq)s',
+     'advpng3': 'advpng -z3 -f %(targetfnq)s',
+     'advpng4': 'advpng -z4 -f %(targetfnq)s',  # Slowest, this uses Zopfli.

--- a/packages/pdfsizeopt/image_optim.patch
+++ b/packages/pdfsizeopt/image_optim.patch
@@ -1,36 +1,38 @@
 diff --git a/lib/pdfsizeopt/main.py b/lib/pdfsizeopt/main.py
-index 48b2791..be0f342 100644
+index 48b2791..66f7f59 100644
 --- a/lib/pdfsizeopt/main.py
 +++ b/lib/pdfsizeopt/main.py
-@@ -6936,6 +6936,7 @@ class PdfData(object):
+@@ -6936,6 +6936,8 @@ class PdfData(object):
          'targetfnq': ShellQuoteFileName(targetfn),
          'pngout_gray_flags': '',
          'optipng_gray_flags': '',
 +        'pngcrush_gray_flags': '',
++        'image_optim_set_gray_flags': '',
          'sam2p_np_gray_flags': '',
          'sam2p_pr_gray_flags': '',
      }
-@@ -6943,6 +6944,7 @@ class PdfData(object):
+@@ -6943,6 +6945,8 @@ class PdfData(object):
        cmd_values_dict['pngout_gray_flags'] = '-c0 '
        # -nc: No color type reduction.
        cmd_values_dict['optipng_gray_flags'] = '-nc -np '
-+      cmd_values_dict['pngcrush_gray_flags'] = '-c0 '
++      cmd_values_dict['pngcrush_gray_flags'] = '-c 0 '
++      cmd_values_dict['image_optim_set_gray_flags'] = '-c 0 '
        cmd_values_dict['sam2p_np_gray_flags'] = '-s Gray1:Gray2:Gray4:Gray8:stop '
        cmd_values_dict['sam2p_pr_gray_flags'] = '-s Gray1:Gray2:Gray4:Gray8:stop '
      else:
-@@ -7263,8 +7265,9 @@ class PdfData(object):
+@@ -7263,8 +7267,9 @@ class PdfData(object):
    @classmethod
    def _IsSlowCmdName(cls, cmd_name):
      return ('pngout' in cmd_name or 'zopflipng' in cmd_name or
 -            'optipng' in cmd_name or 'ect' in cmd_name or
 -            'advpng' in cmd_name or 'pngwolf' in cmd_name)
 +            'optipng' in cmd_name or 'ect' in cmd_name or 'oxipng' in cmd_name or
-+            'pngcrush' in cmd_name or 'pngquant' in cmd_name or
++            'pngcrush' in cmd_name or 'pngquant' in cmd_name or 'image_optim_set' in cmd_name or
 +            'advpng' in cmd_name or 'pngwolf' in cmd_name or 'image_optim' in cmd_name)
  
    def _ConvertImageWithJbig2(self, image, cmd_name, cmd_pattern, obj_num,
                               color_type):
-@@ -7825,6 +7828,8 @@ class PdfData(object):
+@@ -7825,6 +7830,8 @@ class PdfData(object):
                # New pngout if: 'Unable to compress further: copying
                # original file'
                return_none_if_status = 0x200
@@ -39,7 +41,7 @@ index 48b2791..be0f342 100644
              image_item = self.ConvertImage(
                  sourcefn=oi_image.file_name,
                  is_inverted=oi_image.is_inverted,
-@@ -9431,12 +9436,18 @@ IMAGE_OPTIMIZER_CMD_MAP = {
+@@ -9431,12 +9438,22 @@ IMAGE_OPTIMIZER_CMD_MAP = {
      # We need the -force flag specified to pngout, because on Windows
      # pngout without the -force flag returns with a failure exit code
      # if it can't compress the file any further.
@@ -47,7 +49,11 @@ index 48b2791..be0f342 100644
 -    'jbig2': 'jbig2 -p %(sourcefnq)s >%(targetfnq)s',
 -    'zopflipng': 'zopflipng -y -m --filters=p %(sourcefnq)s %(targetfnq)s',
 +    'image_optim': 'image_optim %(targetfnq)s && ect -9 -strip %(targetfnq)s',
-+    'pngcrush': 'pngcrush -blacken -q -rem alla -cc -reduce %(pngcrush_gray_flags)s%(sourcefnq)s %(targetfnq)s',
++    'oxipng_ect': 'oxipng --interlace 0 --quiet --strip all -o 3 -- %(targetfnq)s && ect -9 -strip %(targetfnq)s',
++    # 'image_optim_set': 'pngcrush -blacken -ow -q -rem alla -reduce %(image_optim_set_gray_flags)s%(targetfnq)s && oxipng --interlace 0 --quiet --strip all -o 3 -- %(targetfnq)s && pngquant --force --output=%(targetfnq)s --quality=100-100 --skip-if-larger --speed=3 256 -- %(targetfnq)s || true && advpng -z3 -f %(targetfnq)s && ect -9 -strip %(targetfnq)s',
++    # 'image_optim_set_all': 'pngcrush -blacken -ow -q -rem alla -reduce %(pngcrush_gray_flags)s%(sourcefnq)s %(targetfnq)s && oxipng --interlace 0 --quiet --strip all -o 3 -- %(targetfnq)s && optipng %(targetfnq)s -clobber -o4 -fix -force %(optipng_gray_flags)s && pngquant --force --output=%(targetfnq)s --quality=100-100 --skip-if-larger --speed=3 256 -- %(targetfnq)s || true && pngout -force %(pngout_gray_flags)s%(targetfnq)s && advpng -z3 -f %(targetfnq)s && ect -9 -strip %(targetfnq)s',
++    # 'image_optim_set_oxipng_max': 'pngcrush -ow -blacken -q -rem alla -reduce %(pngcrush_gray_flags)s%(sourcefnq)s %(targetfnq)s && oxipng --interlace 0 --quiet --strip all -o max -- %(targetfnq)s && optipng %(sourcefnq)s -o4 -fix -force %(optipng_gray_flags)s-out %(targetfnq)s && pngquant --force --output=%(targetfnq)s --quality=100-100 --skip-if-larger --speed=3 256 -- %(sourcefnq)s || true && pngout -force %(pngout_gray_flags)s%(sourcefnq)s %(targetfnq)s && advpng -z3 -f %(targetfnq)s && ect -9 -strip %(targetfnq)s',
++    'pngcrush': 'pngcrush -blacken -ow -q -rem alla -reduce %(pngcrush_gray_flags)s%(targetfnq)s',
 +    'oxipng': 'oxipng --interlace 0 --quiet --strip all -o 3 -- %(targetfnq)s',
 +    'oxipngmax': 'oxipng --interlace 0 --quiet --strip all -o max -- %(targetfnq)s',
 +    'oxipngmaxzopfli': 'oxipng --interlace 0 --quiet --strip all -o max --zopfli -- %(targetfnq)s',


### PR DESCRIPTION
Use `ect` to further compress ZIP archives instead of `advzip`.
Cache which files have been optimized to avoid needlessly re-running expensive optimizations.
Embed metadata in PDF filse with Calibre's `ebook-meta` tool.
Optimize JPEGs losslessly with `jpegli` to acheive the smallest size possible.