### PR TITLE
Squash several bugs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -29,7 +29,7 @@ I plan on coming back to improve these scripts after that.
 
 This repository provides a collection of scripts to make it easier to add various digital media to my collection.
 This includes things like music, audiobooks, ebooks, and comics.
-When purchasing media, it often needs to be renamed, converted, tagged with _correct_ information, and finally uploaded to the appropriate location in my S3-compatible object storage.
+When purchasing media, it often needs to be renamed, converted, tagged with _correct_ information, losslessly optimized to reduce files size, and finally uploaded to the appropriate location on my media server.
 The utilities here aim to automate this as much as possible.
 Ultimately, the workflow should be as simple as downloading the media to the corresponding import directory on my computer.
 There's quite a bit of initial set up that needs to be completed first, though, so that's where we'll begin.
@@ -163,6 +163,17 @@ chmod +x ~/Downloads/ComicTagger-x86_64.AppImage
 import-comics.nu ~/Downloads/ComicTagger-x86_64.AppImage file.acsm
 ----
 
+=== Optimizations
+
+I make use of several utilities to decrease file sizes.
+I only optimize images, ebooks, and comics.
+I don't really mess with audio although I have some experimental options for messing around with that.
+Images are optimized with image_optim using its default settings followed by `efficient-compression-tool`, which can typically gain a small improvement for PNGs.
+For comic book archives and EPUBs, this is easy enough as these are just ZIP archives of files.
+I also optimize the ZIP archive compression with `efficient-compression-tool`.
+For PDFs, I use `minuimus` and `pdfsizeopt`, with a couple tweaks to use `oxipng` with max settings followed by `efficient-compression-tool`.
+This often leads to significant space savings for manga from Fanatical and Humble Bundle, usually 25-35%, but it takes a long time, like 16 hours for a 200 MiB PDF.
+
 == Develop
 
 The `nix develop` command can be used to enter or run commands in an environment with all of the necessary dependencies.
@@ -229,7 +240,7 @@ Refer to the project's link:CODE_OF_CONDUCT.adoc[Code of Conduct] for details.
 
 This repository is licensed under the link:LICENSE[MIT license].
 
-© 2024 Jordan Williams
+© 2024-2025 Jordan Williams
 
 == Authors
 

--- a/flake.lock
+++ b/flake.lock
@@ -94,11 +94,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748540971,
-        "narHash": "sha256-tS/rv/Bey2lqvHhkRPdl4vqNCXqGmp6YC6yU/nbYtWw=",
+        "lastModified": 1750260427,
+        "narHash": "sha256-mbnk66VelTtJbr8KuqkUgPipGoeAN/IImtgOHxGY6BQ=",
         "owner": "jwillikers",
         "repo": "nix-update-scripts",
-        "rev": "aa4af0db85c8963cee387aca2ad6cad3dcfd301d",
+        "rev": "c501a7779e6a986dd4f4a6363259a37c726799aa",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748708770,
-        "narHash": "sha256-q8jG2HJWgooWa9H0iatZqBPF3bp0504e05MevFmnFLY=",
+        "lastModified": 1750622754,
+        "narHash": "sha256-kMhs+YzV4vPGfuTpD3mwzibWUE6jotw5Al2wczI0Pv8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a59eb7800787c926045d51b70982ae285faa2346",
+        "rev": "c7ab75210cb8cb16ddd8f290755d9558edde7ee1",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1748693115,
-        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
+        "lastModified": 1750506804,
+        "narHash": "sha256-VLFNc4egNjovYVxDGyBYTrvVCgDYgENp5bVi9fPTDYc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
+        "rev": "4206c4cb56751df534751b058295ea61357bbbaa",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747372754,
-        "narHash": "sha256-2Y53NGIX2vxfie1rOW0Qb86vjRZ7ngizoo+bnXU9D9k=",
+        "lastModified": 1750684550,
+        "narHash": "sha256-uLtw0iF9mQ94L831NOlQLPX9wm0qzd5yim3rcwACEoM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "80479b6ec16fefd9c1db3ea13aeb038c60530f46",
+        "rev": "fae816c55a75675f30d18c9cbdecc13b970d95d4",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748243702,
-        "narHash": "sha256-9YzfeN8CB6SzNPyPm2XjRRqSixDopTapaRsnTpXUEY8=",
+        "lastModified": 1749194973,
+        "narHash": "sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "1f3f7b784643d488ba4bf315638b2b0a4c5fb007",
+        "rev": "a05be418a1af1198ca0f63facb13c985db4cb3c5",
         "type": "github"
       },
       "original": {

--- a/packages/media-juggler/import-audiobooks.nu
+++ b/packages/media-juggler/import-audiobooks.nu
@@ -59,6 +59,8 @@ def main [
   let cache_directory = [($nu.cache-dir | path dirname) "media-juggler" "import-audiobooks"] | path join
   let optimized_files_cache_file = [$cache_directory optimized.json] | path join
   mkdir $cache_directory
+  let cover_art_directory = [$cache_directory "covers"] | path join
+  mkdir $cover_art_directory
   let config_file = [($nu.default-config-dir | path dirname) "media-juggler" "import-audiobooks-config.json"] | path join
   let config: record = (
     try {
@@ -560,6 +562,7 @@ def main [
     | (
       tag_audiobook
       $temporary_directory
+      $cover_art_directory
       $cache_function
       $submit_all_acoustid_fingerprints
       $combine_chapter_parts

--- a/packages/media-juggler/import-audiobooks.nu
+++ b/packages/media-juggler/import-audiobooks.nu
@@ -640,9 +640,7 @@ def main [
       ^ebook-meta
       ($audiobook.accompanying_documents | first)
       --authors ($primary_authors | str join "&")
-      --author-sort
       --title ($metadata.book.title | use_unicode_in_title)
-      --title-sort
     )
   }
 

--- a/packages/media-juggler/import-audiobooks.nu
+++ b/packages/media-juggler/import-audiobooks.nu
@@ -558,7 +558,7 @@ def main [
 
   let relative_destination_directory = (
     [
-      ($metadata.book.title | sanitize_file_name)
+      ($metadata.book.title | use_unicode_in_title | sanitize_file_name)
     ]
     | prepend (
       if ($metadata.book | get --ignore-errors series | is-not-empty) {
@@ -599,11 +599,11 @@ def main [
         )
         if ($primary_series | is-not-empty) {
           log info $"Primary series is ($primary_series)"
-          $primary_series.name | sanitize_file_name
+          $primary_series.name | use_unicode_in_title | sanitize_file_name
         }
       }
     )
-    | prepend ($primary_authors.name | str join ", " | sanitize_file_name)
+    | prepend ($primary_authors.name | str join ", " | use_unicode_in_title | sanitize_file_name)
     | path join
   )
 
@@ -617,7 +617,7 @@ def main [
       # For multiple files, prefix the name with the index
       let stem = (
         if ($metadata.tracks | length) == 1 {
-          $track.title | sanitize_file_name
+          $track.title | use_unicode_in_title | sanitize_file_name
         } else {
           ($track.index | fill --alignment r --character '0' --width $number_of_digits) + " " + $track.title
         }
@@ -639,8 +639,10 @@ def main [
     (
       ^ebook-meta
       ($audiobook.accompanying_documents | first)
-      --title $metadata.book.title
       --authors ($primary_authors | str join "&")
+      --author-sort
+      --title ($metadata.book.title | use_unicode_in_title)
+      --title-sort
     )
   }
 
@@ -650,7 +652,7 @@ def main [
       let stem = (
         # For a single file, rename the file to match the book.
         if ($audiobook.accompanying_documents | length) == 1 {
-          $metadata.book.title | sanitize_file_name
+          $metadata.book.title | use_unicode_in_title | sanitize_file_name
         # For multiple files, leave the names as is.
         } else {
           $document | path parse | get stem

--- a/packages/media-juggler/import-audiobooks.nu
+++ b/packages/media-juggler/import-audiobooks.nu
@@ -70,10 +70,10 @@ def main [
     }
   )
 
-  let cache_function = {|type, id, update_function, additional_hash|
+  let cache_function = {|type, id, update_function, filename_suffix|
     let filename = (
-      if ($additional_hash | is-not-empty) {
-        $"($id)_($additional_hash).json"
+      if ($filename_suffix | is-not-empty) {
+        $"($id)_($filename_suffix).json"
       } else {
         $"($id).json"
       }

--- a/packages/media-juggler/import-comics.nu
+++ b/packages/media-juggler/import-comics.nu
@@ -1470,13 +1470,6 @@ def main [
   let target_directory = (
     [$destination $authors_subdirectory]
     | append $series_subdirectory
-    | append (
-      if $output_format == "pdf" {
-        $formats.pdf | path parse | get stem | use_unicode_in_title | sanitize_file_name
-      } else {
-        null
-      }
-    )
     | path join
   )
   log debug $"Target directory: ($target_directory)"
@@ -1491,18 +1484,22 @@ def main [
   log debug $"Target destination: ($target_destination)"
   let comic_info_target_destination = (
     if $output_format == "pdf" {
-      [
-        $target_directory
-        ($formats.comic_info | path basename)
-      ] | path join
+      let components = ($formats | get $output_format | path parse);
+      {
+        parent: $target_directory
+        stem: (($components.stem | use_unicode_in_title | sanitize_file_name) + "_ComicInfo")
+        extension: "xml"
+      } | path join
     }
   )
   let cover_target_destination = (
     if $output_format == "pdf" {
-      [
-        $target_directory
-        ($formats.cover | path basename)
-      ] | path join
+      let components = ($formats | get $output_format | path parse);
+      {
+        parent: $target_directory
+        stem: (($components.stem | use_unicode_in_title | sanitize_file_name) + "_cover")
+        extension: ($formats.cover | path parse | get extension)
+      } | path join
     }
   )
 

--- a/packages/media-juggler/import-comics.nu
+++ b/packages/media-juggler/import-comics.nu
@@ -1199,9 +1199,7 @@ def main [
               $input.book
               ...$args
               --authors ($authors | str join "&")
-              --author-sort
               --title $title
-              --title-sort
               --identifier $"comicvine:($comic_vine_id)"
               --identifier $"comicvine-volume:($comic_metadata.series_id)"
           );
@@ -1308,9 +1306,7 @@ def main [
               $input.book
               ...$args
               --authors ($authors | str join "&")
-              --author-sort
               --title $title
-              --title-sort
               --identifier $"comicvine:($comic_vine_id)"
               --identifier $"comicvine-volume:($comic_metadata.series_id)"
           );

--- a/packages/media-juggler/import-ebooks.nu
+++ b/packages/media-juggler/import-ebooks.nu
@@ -549,13 +549,6 @@ def main [
     let target_subdirectory = (
       [$authors_subdirectory]
       # todo Add series subdirectory here
-      | append (
-        if $output_format == "pdf" {
-          $book.book | path parse | get stem | use_unicode_in_title | sanitize_file_name
-        } else {
-          null
-        }
-      )
       | path join
     )
     let target_directory = [$destination $target_subdirectory] | path join
@@ -571,18 +564,22 @@ def main [
     log debug $"Target destination: ($target_destination)"
     let opf_target_destination = (
       if $output_format == "pdf" {
-        [
-          $target_directory
-          ($book.opf | path basename)
-        ] | path join
+        let components = $book.book | path parse;
+        {
+          parent: $target_directory
+          stem: (($components.stem | use_unicode_in_title | sanitize_file_name) + "_metadata")
+          extension: "opf"
+        } | path join
       }
     )
     let cover_target_destination = (
       if $output_format == "pdf" {
-        [
-          $target_directory
-          ($book.cover | path basename)
-        ] | path join
+        let components = $book.book | path parse;
+        {
+          parent: $target_directory
+          stem: (($components.stem | use_unicode_in_title | sanitize_file_name) + "_cover")
+          extension: ($book.cover | path parse | get extension)
+        } | path join
       }
     )
     if $skip_upload {

--- a/packages/media-juggler/import-ebooks.nu
+++ b/packages/media-juggler/import-ebooks.nu
@@ -551,7 +551,7 @@ def main [
       # todo Add series subdirectory here
       | append (
         if $output_format == "pdf" {
-          $book.book | path parse | get stem | sanitize_file_name
+          $book.book | path parse | get stem | use_unicode_in_title | sanitize_file_name
         } else {
           null
         }
@@ -564,7 +564,7 @@ def main [
       let components = $book.book | path parse;
       {
         parent: $target_directory
-        stem: ($components.stem | sanitize_file_name)
+        stem: ($components.stem | use_unicode_in_title | sanitize_file_name)
         extension: $components.extension
       } | path join
     )

--- a/packages/media-juggler/media-juggler-lib-tests.nu
+++ b/packages/media-juggler/media-juggler-lib-tests.nu
@@ -1561,78 +1561,6 @@ def test_parse_audible_asin_from_musicbrainz_release [] {
   test_parse_audible_asin_from_musicbrainz_release_bakemonogatari_part_01
 }
 
-def test_parse_tags_from_musicbrainz_release_bakemonogatari_part_01 [] {
-  let input = open ([$test_data_dir "bakemonogatari_part_01_release.json"] | path join)
-  let expected = [
-    [name count];
-    ["chapters" 1]
-    ["light novel" 1]
-    ["unabridged" 1]
-  ]
-  assert equal ($input | parse_tags_from_musicbrainz_release) $expected
-}
-
-def test_parse_tags_from_musicbrainz_release_baccano_vol_1 [] {
-  let input = open ([$test_data_dir "baccano_vol_1.json"] | path join)
-  let expected = [
-    [name count];
-    ["light novel" 1]
-    ["unabridged" 1]
-  ]
-  assert equal ($input | parse_tags_from_musicbrainz_release) $expected
-}
-
-def test_parse_tags_from_musicbrainz_release [] {
-  test_parse_tags_from_musicbrainz_release_baccano_vol_1
-  test_parse_tags_from_musicbrainz_release_bakemonogatari_part_01
-}
-
-def test_parse_genres_from_musicbrainz_release_bakemonogatari_part_01 [] {
-  let input = open ([$test_data_dir "bakemonogatari_part_01_release.json"] | path join)
-  let expected = [
-    [name count];
-    ["fiction" 1]
-    ["light novel" 1]
-    ["mystery" 1]
-    ["paranormal" 1]
-    ["psychological" 1]
-    ["romance" 1]
-    ["school life" 1]
-    ["supernatural" 1]
-    ["vampire" 1]
-  ]
-  assert equal ($input | parse_tags_from_musicbrainz_release) $expected
-}
-
-def test_parse_genres_from_musicbrainz_release_baccano_vol_1 [] {
-  let input = open ([$test_data_dir "baccano_vol_1.json"] | path join)
-  let expected = [
-    [name count];
-    ["adventure" 1]
-    ["fantasy" 1]
-    ["fiction" 1]
-    ["historical fantasy" 1]
-    ["light novel" 1]
-    ["mystery" 1]
-    ["paranormal" 1]
-    ["supernatural" 1]
-    ["urban fantasy" 1]
-  ]
-  assert equal ($input | parse_tags_from_musicbrainz_release) $expected
-}
-
-def test_parse_genres_from_musicbrainz_release_only_genres_baccano_vol_1 [] {
-  let input = open ([$test_data_dir "baccano_vol_1.json"] | path join)
-  let expected = []
-  assert equal ($input | parse_genres --musicbrainz-genres-only) $expected
-}
-
-def test_parse_genres_from_musicbrainz_release [] {
-  test_parse_genres_from_musicbrainz_release_baccano_vol_1
-  test_parse_genres_from_musicbrainz_release_bakemonogatari_part_01
-  test_parse_genres_from_musicbrainz_release_only_genres_baccano_vol_1
-}
-
 def test_parse_chapters_from_musicbrainz_release_baccano_vol_1 [] {
   let input = open ([$test_data_dir "baccano_vol_1.json"] | path join)
   let expected = [
@@ -4815,7 +4743,6 @@ def main [] {
   test_parse_series_from_musicbrainz_release
   test_parse_audible_asin_from_url
   test_parse_audible_asin_from_musicbrainz_release
-  test_parse_tags_from_musicbrainz_release
   test_parse_chapters_from_tone
   test_chapters_into_tone_format
   test_parse_chapters_from_musicbrainz_release

--- a/packages/media-juggler/media-juggler-lib-tests.nu
+++ b/packages/media-juggler/media-juggler-lib-tests.nu
@@ -2265,6 +2265,56 @@ def test_has_distributor_in_common_name_only_right [] {
   assert equal ($left | has_distributor_in_common $right) true
 }
 
+def test_has_distributor_in_common_no_distributor_left [] {
+  let left = [
+    [id name entity role];
+    ["3e61c686-61a6-459e-a178-b709ebb9eb10" "Syougo Kinugasa" artist "primary author"]
+    ["3e822ea5-fb7e-4048-bffa-f8af76e55538" Tomoseshunsaku artist illustrator]
+    ["158b7958-b872-4944-88a5-fd9d75c5d2e8" "Dragonsteel" label publisher]
+  ]
+  let right: table<id: string, name: string, entity: string, role: string> = [
+    [id name entity role];
+    ["3e61c686-61a6-459e-a178-b709ebb9eb10" "Syougo Kinugasa" artist "primary author"]
+    ["3e822ea5-fb7e-4048-bffa-f8af76e55538" Tomoseshunsaku artist illustrator]
+    ["158b7958-b872-4944-88a5-fd9d75c5d2e8" "Libro.fm" label distributor]
+    ["158b7958-b872-4944-88a5-fd9d75c5d2e8" "Dragonsteel" label publisher]
+  ]
+  assert equal ($left | has_distributor_in_common $right) false
+}
+
+def test_has_distributor_in_common_no_distributor_right [] {
+  let left = [
+    [id name entity role];
+    ["3e61c686-61a6-459e-a178-b709ebb9eb10" "Syougo Kinugasa" artist "primary author"]
+    ["3e822ea5-fb7e-4048-bffa-f8af76e55538" Tomoseshunsaku artist illustrator]
+    ["158b7958-b872-4944-88a5-fd9d75c5d2e8" "Libro.fm" label distributor]
+    ["158b7958-b872-4944-88a5-fd9d75c5d2e8" "Dragonsteel" label publisher]
+  ]
+  let right: table<id: string, name: string, entity: string, role: string> = [
+    [id name entity role];
+    ["3e61c686-61a6-459e-a178-b709ebb9eb10" "Syougo Kinugasa" artist "primary author"]
+    ["3e822ea5-fb7e-4048-bffa-f8af76e55538" Tomoseshunsaku artist illustrator]
+    ["158b7958-b872-4944-88a5-fd9d75c5d2e8" "Dragonsteel" label publisher]
+  ]
+  assert equal ($left | has_distributor_in_common $right) false
+}
+
+def test_has_distributor_in_common_no_distributor_both [] {
+  let left = [
+    [id name entity role];
+    ["3e61c686-61a6-459e-a178-b709ebb9eb10" "Syougo Kinugasa" artist "primary author"]
+    ["3e822ea5-fb7e-4048-bffa-f8af76e55538" Tomoseshunsaku artist illustrator]
+    ["158b7958-b872-4944-88a5-fd9d75c5d2e8" "Dragonsteel" label publisher]
+  ]
+  let right: table<id: string, name: string, entity: string, role: string> = [
+    [id name entity role];
+    ["3e61c686-61a6-459e-a178-b709ebb9eb10" "Syougo Kinugasa" artist "primary author"]
+    ["3e822ea5-fb7e-4048-bffa-f8af76e55538" Tomoseshunsaku artist illustrator]
+    ["158b7958-b872-4944-88a5-fd9d75c5d2e8" "Dragonsteel" label publisher]
+  ]
+  assert equal ($left | has_distributor_in_common $right) true
+}
+
 def test_has_distributor_in_common [] {
   test_has_distributor_in_common_left_empty
   test_has_distributor_in_common_right_empty
@@ -2275,6 +2325,9 @@ def test_has_distributor_in_common [] {
   test_has_distributor_in_common_same_id_different_entity
   test_has_distributor_in_common_name_only_left
   test_has_distributor_in_common_name_only_right
+  test_has_distributor_in_common_no_distributor_left
+  test_has_distributor_in_common_no_distributor_right
+  test_has_distributor_in_common_no_distributor_both
 }
 
 def test_audiobooks_with_the_highest_voted_chapters_tag_empty_tags [] {

--- a/packages/media-juggler/media-juggler-lib-tests.nu
+++ b/packages/media-juggler/media-juggler-lib-tests.nu
@@ -4679,12 +4679,6 @@ def test_append_to_musicbrainz_query [] {
   test_append_to_musicbrainz_query_existing_input_with_transform
 }
 
-def test_parse_genres_and_tags_empty_input [] {
-  let input = {}
-  let expected = null
-  assert equal ($input | parse_genres_and_tags) $expected
-}
-
 def test_parse_genres_and_tags_empty_genres_empty_tags [] {
   let input = {
     genres: []
@@ -4779,7 +4773,6 @@ def test_parse_genres_and_tags_genres_tags [] {
 }
 
 def test_parse_genres_and_tags [] {
-  test_parse_genres_and_tags_empty_input
   test_parse_genres_and_tags_empty_genres_empty_tags
   test_parse_genres_and_tags_genres_empty_tags
   test_parse_genres_and_tags_empty_genres_tags

--- a/packages/media-juggler/media-juggler-lib/mod.nu
+++ b/packages/media-juggler/media-juggler-lib/mod.nu
@@ -6331,7 +6331,7 @@ export def tag_audiobook_tracks_by_musicbrainz_release_id [
               }
             )
             $genres | append $acc
-          } | uniq-by name scope | append $musicbrainz_metadata.book.genres
+          } | uniq-by name scope | append ($musicbrainz_metadata.book | get --ignore-errors genres)
         )
         | upsert book.tags (
           $musicbrainz_metadata.book.series | reduce {|series, acc|
@@ -6343,7 +6343,7 @@ export def tag_audiobook_tracks_by_musicbrainz_release_id [
               }
             )
             $tags | append $acc
-          } | uniq-by name scope | append $musicbrainz_metadata.book.tags
+          } | uniq-by name scope | append ($musicbrainz_metadata.book | get --ignore-errors tags)
         )
       )
     }

--- a/packages/media-juggler/media-juggler-lib/mod.nu
+++ b/packages/media-juggler/media-juggler-lib/mod.nu
@@ -4288,6 +4288,7 @@ export def fetch_release_ids_by_acoustid_fingerprints [
     let matches = (
       $chunk | par-each {|fingerprint|
         let result = $fingerprint | fetch_release_ids_by_acoustid_fingerprint $client_key --retries $retries --retry-delay $retry_delay
+        # log info $"result: ($result)"
         if $result == null {
           log error $"Failed to lookup AcoustID fingerprint on the AcoustID server."
           return null
@@ -5247,7 +5248,6 @@ export def fetch_and_parse_musicbrainz_release [
   }
   try {
     $response | parse_musicbrainz_release
-  # try {
   } catch {|err|
     log error $"Parse failed!\n($err)\n($err.msg)\n"
   }
@@ -5436,6 +5436,12 @@ export def has_distributor_in_common [
   }
   let left_distributors = $left | where role == "distributor"
   let right_distributors = $right | where role == "distributor"
+  if ($left_distributors | is-empty) and ($right_distributors | is-empty) {
+    return true
+  }
+  if ($left_distributors | is-empty) or ($right_distributors | is-empty) {
+    return false
+  }
   let joined_on_id = (
     $left_distributors
     | rename id left_name left_entity

--- a/packages/media-juggler/media-juggler-lib/mod.nu
+++ b/packages/media-juggler/media-juggler-lib/mod.nu
@@ -6256,10 +6256,10 @@ export def tag_audiobook_tracks_by_musicbrainz_release_id [
       (
         $musicbrainz_metadata
         | upsert book.genres (
-          $musicbrainz_metadata.book.series | reduce {|series, acc|
+          $musicbrainz_metadata.book.series | reduce --fold [] {|series, acc|
             let genres = (
               if ($series | get --ignore-errors genres | is-empty) {
-                $series.genres
+                []
               } else {
                 $series.genres | default ($series.scope + " series") scope
               }
@@ -6268,10 +6268,10 @@ export def tag_audiobook_tracks_by_musicbrainz_release_id [
           } | uniq-by name scope | append ($musicbrainz_metadata.book | get --ignore-errors genres)
         )
         | upsert book.tags (
-          $musicbrainz_metadata.book.series | reduce {|series, acc|
+          $musicbrainz_metadata.book.series | reduce --fold [] {|series, acc|
             let tags = (
               if ($series | get --ignore-errors tags | is-empty) {
-                $series.tags
+                []
               } else {
                 $series.tags | default ($series.scope + " series") scope
               }

--- a/packages/media-juggler/media-juggler-lib/mod.nu
+++ b/packages/media-juggler/media-juggler-lib/mod.nu
@@ -3927,16 +3927,6 @@ export def parse_musicbrainz_series []: record -> record<id: string, name: strin
     return null
   }
   let genres_and_tags = $input | select --ignore-errors genres tags | parse_genres_and_tags
-  # let genres = (
-  #   if ($genres_and_tags.genres | is-not-empty) {
-  #     $genres_and_tags.genres | default scope "series"
-  #   }
-  # )
-  # let tags = (
-  #   if ($genres_and_tags.tags | is-not-empty) {
-  #     $genres_and_tags.tags | default scope "series"
-  #   }
-  # )
   let series = {
     id: $input.id
     name: $input.name
@@ -3980,17 +3970,10 @@ export def fetch_and_parse_musicbrainz_series [
   --retry-delay: duration = 3sec
 ]: string -> record {
   let musicbrainz_series_id = $in
-  # let cached_series_file = {parent: $cache, stem: $musicbrainz_series_id, extension: "json"} | path join
   let update_cache = {|type id|
     $id | fetch_musicbrainz_series --retries $retries --retry-delay $retry_delay | parse_musicbrainz_series
-    # $series | save $cached_series_file
-    # $series
   }
-  do $cache "series" $musicbrainz_series_id $update_cache
-  # if ($cached | is-empty) {
-  #   # open $cached_series_file
-  # } else {
-  # }
+  do $cache "series" $musicbrainz_series_id $update_cache null
 }
 
 # Build a tree of subseries going up through the parent series
@@ -5207,7 +5190,6 @@ export def fetch_and_parse_musicbrainz_release [
     log error $"Parse failed!\n($err)\n($err.msg)\n"
   }
 }
-
 
 # Get the embedded AcoustID fingerprint or calculate it for the audio files which do not have one.
 export def get_acoustid_fingerprint [

--- a/packages/media-juggler/media-juggler-lib/mod.nu
+++ b/packages/media-juggler/media-juggler-lib/mod.nu
@@ -3891,7 +3891,7 @@ export def parse_musicbrainz_work []: record -> record<id: string, title: string
 
 # Fetch and parse a MusicBrainz Work by ID
 export def fetch_and_parse_musicbrainz_work [
-  cache: closure
+  cache: closure # Closure that returns parsed work information given a type and a work id
   --retries: int = 3
   --retry-delay: duration = 3sec
 ]: string -> record {
@@ -3968,7 +3968,6 @@ export def parse_musicbrainz_series []: record -> record<id: string, name: strin
 
 # Fetch and parse a MusicBrainz Series by ID.
 export def fetch_and_parse_musicbrainz_series [
-  # cache: directory # Cache directory where parsed series are stored in files named according to mbid, i.e. mbid.json.
   cache: closure # Closure that returns parsed series information given a type and a series id
   --retries: int = 3
   --retry-delay: duration = 3sec


### PR DESCRIPTION
Remove several unnecessary sort flags passed to `eboook-meta`.
Ensure that ebooks in a series are placed in the same directory for [Kavita](https://www.kavitareader.com/) to handle them properly.
Comic PDF's will no longer be placed in a dedicated directory per book, but instead will be placed directly in a corresponding series / author directory.
The ComicInfo.xml and cover are still saved alongside PDFs using the filename of the PDF as a prefix.

* Update the flake to bring in the latest version of `ect`.
* Fix tests.
* Add title to AcoustID submissions.

Note: Submitting AcoustID's via the script doesn't include all of the metadata that it should.
I recommend submitting AcoustID's through Picard until it does.

Squash bugs related to importing audiobooks.
* Allow empty tags/genres.
* Fix parsing genres and tags from series.
* Cache MusicBrainz releases.
* Cache cover art.

Clean up the code a little.

 